### PR TITLE
minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Editor
 .vscode/
-.ipynb_checkpoints/
+*.ipynb_checkpoints/
 
 # Prerequisites
 *.d

--- a/cpu.hpp
+++ b/cpu.hpp
@@ -44,7 +44,7 @@ typedef struct instruction {
 
 class cpu {
     public:
-    uint16_t pc;  // program counter
+    uint16_t pc;    // program counter
     uint8_t ac;     // accumulator
     uint8_t x,y;    // x and y register
     uint8_t sp;     //stack pointer
@@ -75,9 +75,7 @@ class cpu {
     void decode();
     void execute();
     void clock();
-
-    void cycleAdder();
-
+    
     // instructions
     void ADC(); void AND(); void ASL(); void BCC(); 
     void BCS(); void BEQ(); void BIT(); void BMI(); 

--- a/mainMemory.cpp
+++ b/mainMemory.cpp
@@ -6,12 +6,11 @@ uint8_t memRead(uint16_t address){
     return mainMemory[address];
 }
 
-void memWrite(uint16_t address,uint8_t value){
-    mainMemory[address] = value;
-}
-
 // returns a pointer to the value mainMemory[address]
-// this is useful for loading the operand1 and operand2
 uint8_t *memPoint(uint16_t address) {
     return (mainMemory + address);
+}
+
+void memWrite(uint16_t address,uint8_t value){
+    mainMemory[address] = value;
 }

--- a/mainMemory.hpp
+++ b/mainMemory.hpp
@@ -2,9 +2,9 @@
 #define MAIN_MEMORY
 #include <iostream>
 
-//memory operations
+// memory operations
 uint8_t memRead(uint16_t address);
-void memWrite(uint16_t address,uint8_t value);
 uint8_t* memPoint(uint16_t address);
+void memWrite(uint16_t address,uint8_t value);
 
 #endif


### PR DESCRIPTION
Cpu is now a class, there is only one operand now and it points to the necessary value depending on the addressing mode of the instruction. mainMemory now has a function memPoint() that returns a pointer to the value inside memory for this purpose. Perhaps mainMemory should be a class too for safety reasons? Previously high bytes of the address were shifted only 4 bits whereas they should've been shifted by 8 bits. Flags are now expressed as bits of the status register. Instructions are now a struct containing a function pointer, addressingMode enum, cycles, and pageCycles